### PR TITLE
Fix missing watchtimes

### DIFF
--- a/tests/models/test_contest.py
+++ b/tests/models/test_contest.py
@@ -12,19 +12,28 @@ from movie_bet_bot.models.movies import movies
 unittest.TestLoader.sortTestMethodsUsing = None
 
 member1 = movies.Member(
-    "name1",
-    "https://letterboxd.com/moviebetbot/list/test_list_1/detail/",
-    "profile_url1",
+    name="name1",
+    contest_url="https://letterboxd.com/moviebetbot/list/test_list_1/detail/",
+    profile_url="profile_url1",
+    filmlist=movies.FilmList(
+        url="https://letterboxd.com/moviebetbot/list/test_list_1/detail/", films=set()
+    ),
 )
 member2 = movies.Member(
-    "name2",
-    "https://letterboxd.com/moviebetbot/list/test_list_2/detail/",
-    "profile_url2",
+    name="name2",
+    contest_url="https://letterboxd.com/moviebetbot/list/test_list_2/detail/",
+    profile_url="profile_url2",
+    filmlist=movies.FilmList(
+        url="https://letterboxd.com/moviebetbot/list/test_list_2/detail/", films=set()
+    ),
 )
 
 test_c = movies.Contest(
     name="test",
-    members=[member1, member2],
+    members=[
+        member1,
+        member2,
+    ],
 )
 
 contest_dict: Final = {
@@ -46,7 +55,9 @@ class Test_Contest_AsyncIO(unittest.IsolatedAsyncioTestCase):
     async def test_run_contest(self):
         c = copy.deepcopy(test_c)
         assert c.members[0].name == "name1"
+        assert c.members[0].num_films_watched == 0
         assert c.members[1].name == "name2"
+        assert c.members[1].num_films_watched == 0
         await c.update(get_film_details=False, save_on_update=False)
         assert c.members[0].name == "name2"
         assert c.members[0].num_films_watched == 2

--- a/tests/models/test_member.py
+++ b/tests/models/test_member.py
@@ -9,13 +9,13 @@ film2: Final = Film(title="film2", url="filmurl2")
 film3: Final = Film(title="film3", url="filmurl3")
 
 test_member = Member("member1", "contest_url1", "profile_url1")
-test_member.list.url = "url1"
-test_member.list.films.update([film1, film2])
+test_member.filmlist.url = "url1"
+test_member.filmlist.films.update([film1, film2])
 member_dict: Final = {
     "contest_url": test_member.contest_url,
     "profile_url": test_member.profile_url,
     "name": test_member.name,
-    "list": test_member.list.to_dict(),
+    "list": test_member.filmlist.to_dict(),
     "watchtime": test_member.watchtime,
     "films_since_last_update": test_member.num_films_since_last_update,
 }
@@ -26,15 +26,15 @@ class Test_Member(unittest.TestCase):
         member = copy.deepcopy(test_member)
         member_updated = copy.deepcopy(test_member)
 
-        assert member.list == member_updated.list
+        assert member.filmlist == member_updated.filmlist
         assert member.num_films_watched == member_updated.num_films_watched
 
-        member_updated.list.films.update([film3])
-        assert member.list != member_updated.list
+        member_updated.filmlist.films.update([film3])
+        assert member.filmlist != member_updated.filmlist
         assert member.num_films_watched != member_updated.num_films_watched
 
     def test_to_dict(self):
         assert test_member.to_dict() == member_dict
 
     def test_repr(self):
-        assert repr(test_member) == (f"Member(name={test_member.name},list={test_member.list})")
+        assert repr(test_member) == (f"Member(name={test_member.name},list={test_member.filmlist})")


### PR DESCRIPTION
Fix bug where new versions of films were added to member lists without details including watchtimes and poster urls. Change list member variable of Member object to filmlist to prevent confusion with Python builtin. Fix test issue. Fixes #42.